### PR TITLE
Corrigiendo falta de header:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Makefile
 .cache/
 /build/
 scripts/
+.vscode

--- a/core/interpreter/compiler/src/compiler.c
+++ b/core/interpreter/compiler/src/compiler.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "attrs.h"
 #include "block_list.h"


### PR DESCRIPTION
Añadiendo header faltante para la compilacion en sistemas linux amd64, version GNU: ``GNU 15.2.0``, version CLANG: `Clang 19.1.7`

```c
┌──(root㉿DESKTOP-N71RAHT)-[~/WinDiskI/netXenium/build]
└─# cmake ..
-- The C compiler identification is GNU 15.2.0
-- The CXX compiler identification is Clang 19.1.7
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done (2.7s)
-- Generating done (1.8s)
-- Build files have been written to: /root/WinDiskI/netXenium/build

┌──(root㉿DESKTOP-N71RAHT)-[~/WinDiskI/netXenium/build]
└─# make
[  0%] Building C object CMakeFiles/libntxenium.dir/abi/src/abi.c.o
[  0%] Building C object CMakeFiles/libntxenium.dir/core/src/xen_life.c.o
[  1%] Building C object CMakeFiles/libntxenium.dir/core/src/program.c.o
[  1%] Building C object CMakeFiles/libntxenium.dir/core/src/read_string_utf8.c.o

.....

/root/WinDiskI/netXenium/core/interpreter/compiler/src/compiler.c: In function ‘compile_decl_statement’:
/root/WinDiskI/netXenium/core/interpreter/compiler/src/compiler.c:2162:9: error: implicit declaration of function ‘strcmp’ [-Wimplicit-function-declaration]
 2162 |     if (strcmp(type, "local") == 0) {
      |         ^~~~~~
/root/WinDiskI/netXenium/core/interpreter/compiler/src/compiler.c:33:1: note: include ‘<string.h>’ or provide a declaration of ‘strcmp’
   32 | #include "xen_vector.h"
  +++ |+#include <string.h>
   33 |
make[2]: *** [CMakeFiles/libntxenium.dir/build.make:723: CMakeFiles/libntxenium.dir/core/interpreter/compiler/src/compiler.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:161: CMakeFiles/libntxenium.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```